### PR TITLE
Update docusaurus.config.ts to support new url

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,10 +15,10 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://ledgerlink-ai.github.io',
+  url: 'https://docs.ledgerlink.ai',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/docs/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
After setting up the DNS for ledgerlink docs https://docs.ledgerlink.ai/, the website complain about the base url.
This fix should fix the warning

<img width="1589" height="757" alt="image" src="https://github.com/user-attachments/assets/afe355e9-72d2-44a9-a9fd-7ef04bf9a6b6" />

@rafael-ledgerlink I might need your help to deploy this changes. 