### PR TITLE
Split deploy workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,13 @@ on:
       - main
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: 'Skip build and use existing artifact (for retrying failed deploys)'
+        required: false
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: read
@@ -13,12 +20,10 @@ permissions:
   id-token: write
 
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    if: ${{ github.event_name == 'push' || inputs.skip_build != true }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,8 +106,17 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ always() && (needs.build.result == 'success' || inputs.skip_build == true) }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Separates the GitHub Actions workflow into two distinct jobs:
- build: checkout, submodules, build, and upload artifact
- deploy: deploy artifact to GitHub Pages

Adds workflow_dispatch trigger with skip_build option to retry failed deploys without rebuilding.